### PR TITLE
Risolto conflitti di nomenclatura

### DIFF
--- a/include/Movement.h
+++ b/include/Movement.h
@@ -1,7 +1,7 @@
 #ifndef movement_h
 #define movement_h
 
-#include "coordinate.h"
+#include "Coordinate.h"
 
 #include <ostream>
 

--- a/include/Piece.h
+++ b/include/Piece.h
@@ -1,10 +1,10 @@
 #ifndef piece_h
 #define piece_h
 
-#include "utilities.h"
-#include "coordinate.h"
-#include "movement.h"
-#include "board.h"
+#include "Utilities.h"
+#include "Coordinate.h"
+#include "Movement.h"
+#include "Board.h"
 
 #include <list>
 #include <memory> //get_pseudo_valid_movements of derived classes use shared_ptr<Piece>

--- a/include/Player.h
+++ b/include/Player.h
@@ -1,8 +1,8 @@
 #ifndef player_h
 #define player_h
 
-#include "utilities.h"
-#include "piece.h"
+#include "Utilities.h"
+#include "Piece.h"
 
 #include <list>
 #include <memory>

--- a/include/pieces/King.h
+++ b/include/pieces/King.h
@@ -1,7 +1,7 @@
-#ifndef king_piece_h
-#define king_piece_h
+#ifndef king_h
+#define king_h
 
-#include "piece.h"
+#include "Piece.h"
 
 namespace Chess {
 

--- a/src/coordinate.cpp
+++ b/src/coordinate.cpp
@@ -1,4 +1,4 @@
-#include "coordinate.h"
+#include "Coordinate.h"
 #include <string>
 
 using Chess::Coordinate;

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -1,4 +1,4 @@
-#include "movement.h"
+#include "Movement.h"
 
 using Chess::Movement;
 

--- a/src/pieces/king.cpp
+++ b/src/pieces/king.cpp
@@ -1,31 +1,39 @@
-#include "king_piece.h"
+#include "King.h"
 
 using Chess::KingPiece;
 
 using Chess::Movement;
+using Chess::utilities::Color;
 using Chess::utilities::Direction;
 using Chess::utilities::DirectionOffset;
-using Chess::utilities::Color;
 using Chess::utilities::PieceType;
 
-KingPiece::KingPiece(Coordinate coordinate, Color color, PieceType type) : Piece{coordinate, color, type} {
+KingPiece::KingPiece(Coordinate coordinate, Color color, PieceType type) : Piece{coordinate, color, type}
+{
     symbol = (color == Color::black) ? 'R' : 'r';
 }
 
-std::list<Movement> KingPiece::get_pseudo_valid_movements(Board& board) {
+std::list<Movement> KingPiece::get_pseudo_valid_movements(Board &board)
+{
     std::list<Movement> pseudo_movements;
-    for (int i = 0; i < 8; i++) {
+    for (int i = 0; i < 8; i++)
+    {
         std::shared_ptr<Piece> test_piece;
         Direction direction = static_cast<Direction>(i);
         std::pair<int, int> offset = DirectionOffset.at(direction);
         Coordinate test_coordinate = coordinate + offset;
-        while(test_coordinate.is_valid()) {
+        while (test_coordinate.is_valid())
+        {
             test_piece = board.get_piece_at(test_coordinate);
-            if(test_piece == nullptr) {
+            if (test_piece == nullptr)
+            {
                 pseudo_movements.push_back({coordinate, test_coordinate});
-            } else {
+            }
+            else
+            {
                 Color test_piece_color = test_piece->get_color();
-                if(color != test_piece_color) {
+                if (color != test_piece_color)
+                {
                     pseudo_movements.push_back({coordinate, test_coordinate});
                 }
                 break;


### PR DESCRIPTION
Molti include falliscono a causa di nomi errati. Consiglio di tenere sempre la maiuscola negli header e tutto minuscolo nei cpp. Inoltre credo sia più leggibile se rinominassimo i pezzi da `name_piece[.cpp/.h]` a solo `name[.cpp/.h]`